### PR TITLE
Remove RGFW Submodule and Use Zig Dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "submodules/rgfw"]
-	path = submodules/rgfw
-	url = https://github.com/ColleagueRiley/RGFW.git

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,6 +2,12 @@
     .name = .rgfw,
     .fingerprint = 0x502c4210e0d3063a,
     .version = "0.1.0",
+    .dependencies = .{
+        .rgfw = .{
+            .url = "git+https://github.com/ColleagueRiley/RGFW.git#d19886cf9ff17e5f11de6df1a0f0a84a7c2db39d",
+            .hash = "N-V-__8AAH9sPQANXocQzWSTAMZeQXKSQs50WCEe0YPz2vWB",
+        },
+    },
     .minimum_zig_version = "0.15.1",
     .paths = .{
         ".gitmodules",

--- a/src/build/RgfwLib.zig
+++ b/src/build/RgfwLib.zig
@@ -29,6 +29,14 @@ pub fn init(b: *std.Build, build_config: *const BuildConfig) RgfwLib {
         .root_module = rgfw_lib_module,
     });
 
+    // We're pulling in RGFW as a Zig dependency even though it's not written in Zig. This is due
+    // to the fact that Zig dependencies can't have submodules (lame)
+    const rgfw_dependency = b.dependency("rgfw", .{
+        .optimize = build_config.optimize,
+        .target = build_config.target,
+    });
+    lib.addIncludePath(rgfw_dependency.path(""));
+
     // LibC is required to build RGFW. This is something I'd like to distance myself from in future
     // Manatee development, but RGFW gets me where I need to be for now, so this is fine
     lib.root_module.link_libc = true;
@@ -70,7 +78,6 @@ pub fn init(b: *std.Build, build_config: *const BuildConfig) RgfwLib {
     // Zig has an open issue where header-only C libraries like RGFW can't be added to a module
     // without a C file. Once this is fixed, we shouldn't have to create a C file and should be
     // able to import the header only and be good to go!
-    lib.addIncludePath(.{ .cwd_relative = "./submodules/rgfw" });
     lib.addCSourceFile(.{
         .file = b.addWriteFiles().add("rgfw.c", "#include <RGFW.h>"),
     });


### PR DESCRIPTION
# Description

This PR updates zig-rgfw to use a Zig dependency to fetch RGFW rather than a Git submodule, as it turns out Zig can't really fetch submodules when fetching git-based dependencies (womp womp)

# Testing

Please describe the tests that can be run to verify your changes, as well as reproduction
instructions if applicable.

1. Ran `zig fetch --save=zig-rgfw https://github.com/manateeengine/zig-rgfw/archive/refs/heads/replace-submodule-with-zig-dep.zip` to add the module to the working copy of Manatee.
2. Ran the test window creation code on both Windows and MacOS to ensure that this dep actually worked
3. Observed an open window (yay)

Screenshot from MacOS 15:

<img width="912" height="712" alt="Screenshot 2025-09-25 at 11 32 50 AM" src="https://github.com/user-attachments/assets/3eee632f-d433-49e6-b57c-069219853073" />

Screenshot from Windows 11:

<img width="802" height="632" alt="image" src="https://github.com/user-attachments/assets/e75bdc24-8028-4f78-af03-a43188cabf9b" />

# Checklist

- [x] My changes follow the code contribution guidelines
- [x] My changes follow the code of conduct
